### PR TITLE
Split out randomx-types package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,8 +118,17 @@ dependencies = [
  "hex",
  "libc",
  "rand",
+ "randomx-types",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "randomx-types"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,13 @@ libc = "0.2"
 thiserror = "1.0"
 
 serde = { version = "1.0", features = ["derive"] }
+randomx-types = { version = "0.1.0", path = "crates/randomx-types" }
 
 [dev-dependencies]
 rand = "0.8"
 
 [build-dependencies]
 cmake = "0.1"
+
+[workspace]
+members = ["crates/randomx-types"]

--- a/crates/randomx-types/Cargo.toml
+++ b/crates/randomx-types/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "randomx-types"
+version = "0.1.0"
+description = "RandomX Rust wrapper common types intended for Fluence Capacity Commitment prover and verifier"
+authors = ["Fluence Labs"]
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/fluencelabs/randomx-rust-wrapper"
+publish = true
+
+[lib]
+path = "src/lib.rs"
+doctest = false
+
+[dependencies]
+hex = "0.4"
+# thiserror = "1.0"
+
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/randomx-types/src/lib.rs
+++ b/crates/randomx-types/src/lib.rs
@@ -26,35 +26,6 @@
     unreachable_patterns
 )]
 
-pub mod bindings;
-pub mod cache;
-pub mod dataset;
-pub mod errors;
-pub mod flags;
-#[cfg(test)]
-mod tests;
-pub mod vm;
+mod result_hash;
 
-pub use ::randomx_types::ResultHash;
-
-pub type RResult<T> = Result<T, errors::RandomXError>;
-
-pub use cache::Cache;
-pub use dataset::Dataset;
-pub use errors::RandomXError;
-pub use errors::VmCreationError;
-pub use flags::RandomXFlags;
-pub use vm::RandomXVM;
-
-macro_rules! try_alloc {
-    ($alloc:expr, $error:expr) => {{
-        let result = unsafe { $alloc };
-        if result.is_null() {
-            return Err($error)?;
-        }
-
-        result
-    }};
-}
-
-pub(crate) use try_alloc;
+pub use result_hash::*;

--- a/crates/randomx-types/src/result_hash.rs
+++ b/crates/randomx-types/src/result_hash.rs
@@ -36,11 +36,11 @@ impl ResultHash {
         self.0
     }
 
-    pub(crate) fn empty() -> Self {
+    pub fn empty() -> Self {
         Self([0u8; RANDOMX_RESULT_SIZE])
     }
 
-    pub(crate) fn as_raw_mut(&mut self) -> *mut std::ffi::c_void {
+    pub fn as_raw_mut(&mut self) -> *mut std::ffi::c_void {
         self.0.as_mut_ptr() as *mut std::ffi::c_void
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -21,9 +21,9 @@ use crate::dataset::Dataset;
 use crate::dataset::DatasetRawAPI;
 use crate::errors::VmCreationError;
 use crate::flags::RandomXFlags;
-use crate::result_hash::ResultHash;
 use crate::try_alloc;
 use crate::RResult;
+use crate::ResultHash;
 
 #[derive(Debug)]
 pub struct RandomXVM<T> {


### PR DESCRIPTION
So that packages that depend on ccp-shared do not need to build RandomX.